### PR TITLE
Fix require.resolve issue for Node 12

### DIFF
--- a/src/requireLocal.js
+++ b/src/requireLocal.js
@@ -1,9 +1,9 @@
-const { compose, partialRight } = require('ramda')
+const { compose, concat, partialRight } = require('ramda')
 
 const resolveLocal =
   partialRight(require.resolve, [{ paths: [ process.cwd() ] }])
 
 const requireLocal =
-  compose(require, resolveLocal)
+  compose(require, resolveLocal, concat('./'))
 
 module.exports = requireLocal


### PR DESCRIPTION
![](https://media.giphy.com/media/9x35XQfOmxWSI/giphy.gif)

Issue here in Node 12 - https://github.com/nodejs/node/issues/27583

In attempting to upgrade the lambda docker image to Node 12, it failed to load the `src/lambda/index` file based in because of a change in `require.resolve` as documented in the issue above.  This fix works still with Node 8+